### PR TITLE
fix:[rank]하단 내 랭킹정보에서 게임명칭 변경

### DIFF
--- a/src/app/games/rank/page.tsx
+++ b/src/app/games/rank/page.tsx
@@ -192,15 +192,15 @@ const RankingPage = async () => {
                 </div>
                 <div className='flex flex-col justify-between self-stretch w-full max-w-[15.25rem] title-16'>
                   <div className='flex items-center justify-between'>
-                    <div className='text-primary-700'>주어진 문장읽기</div>
+                    <div className='text-primary-700'>나야, 발음왕</div>
                     <div className='text-primary-600'>{userTable?.[0]?.speaking}점</div>
                   </div>
                   <div className='flex items-center justify-between'>
-                    <div className='text-primary-700'>빈칸채우기</div>
+                    <div className='text-primary-700'>빈칸 한 입</div>
                     <div className='text-primary-600'>{userTable?.[0]?.writing}점</div>
                   </div>
                   <div className='flex items-center justify-between'>
-                    <div className='text-primary-700'>틀린것 맞추기</div>
+                    <div className='text-primary-700'>틀린 말 탐정단</div>
                     <div className='text-primary-600'>{userTable?.[0]?.checking}점</div>
                   </div>
                   <div className='flex items-center justify-between'>


### PR DESCRIPTION
<img width="278" alt="스크린샷 2024-11-12 오후 9 09 46" src="https://github.com/user-attachments/assets/c59e9a3c-ba34-47c5-8c99-3e0fbbe20a93">

- 첨부된 이미지로 rank 하단에 들어가는 게임 명칭 변경하였습니다.

확인부탁드립니다. 